### PR TITLE
Solution for issue #23

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CREATE_TOPICS: "order:5:1"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   apache:
     build: apache
     links:


### PR DESCRIPTION
See #23 for a description of the issue. This seems like a consistent fix for that issue in my testing. 

Doesn't seem like it hurts to have auto topic creation disabled for anybody who will never encounter this odd timing regardless. 
It appears to me that (in the use case of this sample app) having full control over how many topic partitions there are at all times, overruling any possible random default, would be the absolute desirable behaviour here. 